### PR TITLE
Add PEP 561 `py.typed` marker to enable type-checking of `vidua` module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5.x, 3.6.x, 3.7.x, 3.8.x, 3.9.x]
+        python-version: [3.7.x, 3.8.x, 3.9.x, 3.10.x, 3.11.x]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(name='vidua',
           'Topic :: Utilities',
       ],
       packages=['vidua'],
+      package_data={
+        'vidua': ['py.typed'],
+      },
       entry_points={
         'console_scripts': [
             'vidua = vidua.scripts:main',


### PR DESCRIPTION
Hi there, I'm currently using your library in my project, and it's been extremely useful! I noticed that vidua's functions are type-annotated, but it doesn't expose those types for downstreams via a [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information) `py.typed` marker. Would you consider adding one so that downstreams can properly type-check their usage of `vidua`? Currently, in order to use `mypy` on a project with `vidua` as a dependency, one must tell `mypy` to ignore `vidua` types by enabling the [`ignore-missing-imports`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-ignore-missing-imports) option. Otherwise, `mypy` will fail with a message like this https://github.com/phst-randomizer/ph-randomizer/actions/runs/4486066161/jobs/7888209742?pr=318#step:9:25.

I recognize that exposing types adds an additional maintenance burden, so if they're only intended for internal use, I understand. I'm currently working on getting my project as fully-typed as possible, so I figured I'd at least inquire to see if this would be considered :)

(Also - I noticed CI was failing due to Python 3.5 and 3.6 no longer being supported by the `setup-python` action. I went ahead and removed them and added 3.10 and 3.11 in their place)